### PR TITLE
Added support for existing namespace for istio controlplane

### DIFF
--- a/examples/existing_cluster/main.tf
+++ b/examples/existing_cluster/main.tf
@@ -147,12 +147,12 @@ module "default_workload_egress" {
 }
 
 ##############################################################################
-# Deploy BookInfo sample app
+# Deploy httpbin sample app
 ##############################################################################
 
 resource "kubernetes_namespace_v1" "sample_app_namespace" {
   metadata {
-    name = "bookinfo-v3"
+    name = "httpbin"
     labels = {
       "istio-discovery" : var.istio_controlplane_name
       "istio.io/rev" : var.istio_controlplane_name
@@ -176,7 +176,7 @@ resource "helm_release" "sample_app" {
 
   name                       = "httpbin-sample-app"
   chart                      = "../charts/sample-app/httpbin"
-  namespace                  = "httpbin"
+  namespace                  = kubernetes_namespace_v1.sample_app_namespace.metadata[0].name
   create_namespace           = false
   timeout                    = 300
   cleanup_on_fail            = true

--- a/examples/existing_cluster/main.tf
+++ b/examples/existing_cluster/main.tf
@@ -188,7 +188,7 @@ resource "helm_release" "sample_app" {
     value = "httpbin"
     }, {
     name  = "gateway.istioSelector"
-    value = "ingress-gateway"
+    value = "ingress-gw"
     },
     {
       name  = "gateway.istioPort"

--- a/modules/sm-istio/README.md
+++ b/modules/sm-istio/README.md
@@ -177,6 +177,8 @@ For all the configuration parameters details refer to the section below
 | Name | Type |
 |------|------|
 | [helm_release.istio_controlplane](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_annotations.istio_namespace_annotations](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/annotations) | resource |
+| [kubernetes_labels.istio_namespace_labels](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/labels) | resource |
 | [null_resource.confirm_istio_operational](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [ibm_container_cluster_config.cluster_config](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/data-sources/container_cluster_config) | data source |
 
@@ -184,6 +186,7 @@ For all the configuration parameters details refer to the section below
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_add_istio_labels_annotations_to_existing_namespace"></a> [add\_istio\_labels\_annotations\_to\_existing\_namespace](#input\_add\_istio\_labels\_annotations\_to\_existing\_namespace) | Flag to add istio labels and annotations like the discovery ones or the value of var.istio\_namespace\_discovery\_custom\_labels to an existing namespace. Default to false. If var.create\_namespace is true this flag is ignored. | `bool` | `false` | no |
 | <a name="input_cluster_config_endpoint_type"></a> [cluster\_config\_endpoint\_type](#input\_cluster\_config\_endpoint\_type) | Specify which type of endpoint to use for for cluster config access: 'default', 'private', 'vpe', 'link'. 'default' value will use the default endpoint of the cluster. | `string` | `"default"` | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Id of the target IBM Cloud OpenShift Cluster | `string` | n/a | yes |
 | <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Flag to create the namespace where to install istio controlplane. Default to true | `bool` | `true` | no |

--- a/modules/sm-istio/main.tf
+++ b/modules/sm-istio/main.tf
@@ -118,6 +118,28 @@ module "istio_namespace" {
   ]
 }
 
+# labels to add to an existing namespace
+resource "kubernetes_labels" "istio_namespace_labels" {
+  count       = var.create_namespace == false && var.add_istio_labels_annotations_to_existing_namespace == true ? 1 : 0
+  api_version = "v1"
+  kind        = "Namespace"
+  metadata {
+    name = var.namespace
+  }
+  labels = local.istio_namespace_discovery_labels
+}
+
+# annotations to add to an existing namespace
+resource "kubernetes_annotations" "istio_namespace_annotations" {
+  count       = var.create_namespace == false && var.add_istio_labels_annotations_to_existing_namespace == true ? 1 : 0
+  api_version = "v1"
+  kind        = "Namespace"
+  metadata {
+    name = var.namespace
+  }
+  annotations = local.istio_namespace_discovery_labels
+}
+
 # installing helm chart for istio deployment
 resource "helm_release" "istio_controlplane" {
   depends_on       = [module.istio_namespace[0]]

--- a/modules/sm-istio/variables.tf
+++ b/modules/sm-istio/variables.tf
@@ -34,6 +34,12 @@ variable "create_namespace" {
   default     = true
 }
 
+variable "add_istio_labels_annotations_to_existing_namespace" {
+  type        = bool
+  description = "Flag to add istio labels and annotations like the discovery ones or the value of var.istio_namespace_discovery_custom_labels to an existing namespace. Default to false. If var.create_namespace is true this flag is ignored."
+  default     = false
+}
+
 variable "namespace" {
   type        = string
   description = "Namespace where to install istio controlplane."

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -20,6 +20,11 @@ func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptio
 		TerraformDir:  dir,
 		Prefix:        prefix,
 		ResourceGroup: resourceGroup,
+		IgnoreUpdates: testhelper.Exemptions{ // Ignore for consistency check
+			List: []string{
+				"module.service_mesh_operator.terraform_data.undeploy_servicemesh[0]",
+			},
+		},
 	})
 	return options
 }


### PR DESCRIPTION
### Description

added support for existing namespace for istio controlplane

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

added support for existing namespace for istio controlplane

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
