### PR TITLE
fix: restored internalTrafficPolicy in egress definition

### DIFF
--- a/chart/istio-egress/templates/svc.yaml
+++ b/chart/istio-egress/templates/svc.yaml
@@ -6,8 +6,7 @@ metadata:
   annotations:
 spec:
   type: {{ .Values.egress.svctype }}
-  # externalTrafficPolicy: {{ .Values.egress.externalTrafficPolicy }}
-  # internalTrafficPolicy: {{ .Values.egress.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ .Values.egress.internalTrafficPolicy }}
   selector:
   {{- if .Values.egress.istioselectors }}
   {{- toYaml .Values.egress.istioselectors | nindent 4 }}

--- a/chart/istio-egress/values.yaml
+++ b/chart/istio-egress/values.yaml
@@ -8,8 +8,7 @@ egress:
     name: svc-http
     proto: TCP # UDP
     targetPort: 8080
-  externalTrafficPolicy: Cluster
-  internalTrafficPolicy: Local
+  internalTrafficPolicy: Cluster
   autoscale:
     enabled: false
     # autoscaleMin: 1


### PR DESCRIPTION
### Description

restored internalTrafficPolicy in egress definition

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

restored internalTrafficPolicy in egress definition

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
