### PR TITLE
fix: fixed helm chart indentations for istio ingress gateway annotations

### DIFF
--- a/chart/istio-ingress/templates/albsvc.yaml
+++ b/chart/istio-ingress/templates/albsvc.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- end }}
     {{- end }}
     {{- if .Values.ingress.customAnnotations }}
-    {{- toYaml .Values.ingress.customAnnotations | nindent 6 }}
+    {{- toYaml .Values.ingress.customAnnotations | nindent 4 }}
     {{- end }}
 spec:
   type: {{ .Values.ingress.svctype }}

--- a/chart/istio-ingress/templates/genericsvc.yaml
+++ b/chart/istio-ingress/templates/genericsvc.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
     {{- end }}
     {{- if .Values.ingress.customAnnotations }}
-    {{- toYaml .Values.ingress.customAnnotations | nindent 6 }}
+    {{- toYaml .Values.ingress.customAnnotations | nindent 4 }}
     {{- end }}
 spec:
   type: {{ .Values.ingress.svctype }}

--- a/chart/istio-ingress/templates/nlbsvc.yaml
+++ b/chart/istio-ingress/templates/nlbsvc.yaml
@@ -10,7 +10,7 @@ metadata:
     service.kubernetes.io/ibm-load-balancer-cloud-provider-vpc-subnets: {{ $lb_subnet | quote}}
     service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type: {{ $.Values.ingress.lbiptype }}
     {{- if .Values.ingress.customAnnotations }}
-    {{- toYaml .Values.ingress.customAnnotations | nindent 6 }}
+    {{- toYaml .Values.ingress.customAnnotations | nindent 4 }}
     {{- end }}
 spec:
   type: {{ $.Values.ingress.svctype }}


### PR DESCRIPTION
### Description

fixed helm chart indentations for istio ingress gateway annotations

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

fixed helm chart indentations for istio ingress gateway annotations

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
