### PR TITLE
feat: added output values for hostnames and IPs in ingress submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ module "basic_workload_ingress" {
       "name" : "http2"
       "port" : "80"
       "targetPort" : "8000"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     }
   ]
   cluster_config_file_path = data.ibm_container_cluster_config.cluster_config.config_file_path
@@ -214,13 +214,13 @@ module "default_workload_egress" {
       "name" : "http2"
       "port" : "80"
       "targetPort" : "8000"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     },
     {
       "name" : "https"
       "port" : "443"
       "targetPort" : "443"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     }
   ]
   cluster_config_file_path = data.ibm_container_cluster_config.cluster_config.config_file_path

--- a/chart/istio-egress/templates/deployment.yaml
+++ b/chart/istio-egress/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
         {{- if .Values.egress.ports }}
         {{- range .Values.egress.ports }}
         - containerPort: {{ .port }}
-          protocol: {{ .proto | toString }}
+          protocol: {{ .protocol | toString }}
           name: {{ .name }}
         {{- end }}
         {{- end }}

--- a/chart/istio-egress/templates/svc.yaml
+++ b/chart/istio-egress/templates/svc.yaml
@@ -15,7 +15,7 @@ spec:
   {{- if .Values.egress.ports }}
   {{- range .Values.egress.ports }}
   - port: {{ .port }}
-    protocol: {{ .proto | toString }}
+    protocol: {{ .protocol | toString }}
     name: {{ .name | toString }}
     targetPort: {{ .targetPort }}
   {{- end }}

--- a/chart/istio-egress/values.yaml
+++ b/chart/istio-egress/values.yaml
@@ -6,7 +6,7 @@ egress:
   ports:
   - port: 80
     name: svc-http
-    proto: TCP # UDP
+    protocol: TCP # UDP
     targetPort: 8080
   internalTrafficPolicy: Cluster
   autoscale:

--- a/chart/istio-ingress/templates/albdeployment.yaml
+++ b/chart/istio-ingress/templates/albdeployment.yaml
@@ -71,7 +71,7 @@ spec:
         {{- if .Values.ingress.ports }}
         {{- range .Values.ingress.ports }}
         - containerPort: {{ .port }}
-          protocol: {{ .proto | toString }}
+          protocol: {{ .protocol | toString }}
           name: {{ .name }}
         {{- end }}
         {{- end }}

--- a/chart/istio-ingress/templates/albsvc.yaml
+++ b/chart/istio-ingress/templates/albsvc.yaml
@@ -33,7 +33,7 @@ spec:
   {{- if .Values.ingress.ports }}
   {{- range .Values.ingress.ports }}
   - port: {{ .port }}
-    protocol: {{ .proto | toString }}
+    protocol: {{ .protocol | toString }}
     name: {{ .name | toString }}
     targetPort: {{ .targetPort }}
   {{- end }}

--- a/chart/istio-ingress/templates/genericsvc.yaml
+++ b/chart/istio-ingress/templates/genericsvc.yaml
@@ -25,7 +25,7 @@ spec:
   {{- if .Values.ingress.ports }}
   {{- range .Values.ingress.ports }}
   - port: {{ .port }}
-    protocol: {{ .proto | toString }}
+    protocol: {{ .protocol | toString }}
     name: {{ .name | toString }}
     targetPort: {{ .targetPort }}
   {{- end }}

--- a/chart/istio-ingress/templates/nlbdeployment.yaml
+++ b/chart/istio-ingress/templates/nlbdeployment.yaml
@@ -76,7 +76,7 @@ spec:
         {{- if $.Values.ingress.ports }}
         {{- range $.Values.ingress.ports }}
         - containerPort: {{ .port }}
-          protocol: {{ .proto | toString }}
+          protocol: {{ .protocol | toString }}
           name: {{ .name }}
         {{- end }}
         {{- end }}

--- a/chart/istio-ingress/templates/nlbsvc.yaml
+++ b/chart/istio-ingress/templates/nlbsvc.yaml
@@ -24,7 +24,7 @@ spec:
   {{- if $.Values.ingress.ports }}
   {{- range $.Values.ingress.ports }}
   - port: {{ .port }}
-    protocol: {{ .proto | toString }}
+    protocol: {{ .protocol | toString }}
     name: {{ .name | toString }}
     targetPort: {{ .targetPort }}
   {{- end }}

--- a/chart/istio-ingress/values.yaml
+++ b/chart/istio-ingress/values.yaml
@@ -19,7 +19,7 @@ ingress:
   ports:
   - port: 80
     name: svc-http
-    proto: TCP # UDP
+    protocol: TCP # UDP
     targetPort: 8080
   externalTrafficPolicy: Cluster
   internalTrafficPolicy: Local

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -148,7 +148,7 @@ module "basic_workload_ingress" {
       "name" : "http2"
       "port" : "80"
       "targetPort" : "8000"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     }
   ]
   cluster_id        = module.ocp_base.cluster_id
@@ -172,13 +172,13 @@ module "default_workload_egress" {
       "name" : "http2"
       "port" : "80"
       "targetPort" : "8000"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     },
     {
       "name" : "https"
       "port" : "443"
       "targetPort" : "443"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     }
   ]
   cluster_id        = module.ocp_base.cluster_id

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -7,3 +7,17 @@ output "vpc_id" {
   description = "ID of the deployed VPC"
   value       = module.ocp_base.vpc_id
 }
+
+##############################################################################
+# Ingress Service Details Outputs
+##############################################################################
+
+output "ingress_loadbalancer_hostname" {
+  description = "Load balancer hostname(s) - map of service name to hostname for ALB and NLB types, empty map for other types"
+  value       = module.basic_workload_ingress.ingress_loadbalancer_hostname
+}
+
+output "ingress_loadbalancer_ips" {
+  description = "Load balancer IPs - map of service_name to IP for NLB type, map of indexed keys to IPs for other types, empty map for ALB"
+  value       = module.basic_workload_ingress.ingress_loadbalancer_ips
+}

--- a/examples/existing_cluster/main.tf
+++ b/examples/existing_cluster/main.tf
@@ -108,7 +108,7 @@ module "basic_workload_ingress" {
       "name" : "http2"
       "port" : "80"
       "targetPort" : "9080"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     }
   ]
   cluster_id          = var.existing_cluster_id
@@ -133,13 +133,13 @@ module "default_workload_egress" {
       "name" : "http2"
       "port" : "80"
       "targetPort" : "8000"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     },
     {
       "name" : "https"
       "port" : "443"
       "targetPort" : "443"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     }
   ]
   cluster_id        = var.existing_cluster_id

--- a/modules/sm-istio-egress/README.md
+++ b/modules/sm-istio-egress/README.md
@@ -51,13 +51,13 @@ module "default_workload_egress" {
       "name" : "http2"
       "port" : "80"
       "targetPort" : "8000"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     },
     {
       "name" : "https"
       "port" : "443"
       "targetPort" : "443"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     }
   ]
   cluster_config_file_path = data.ibm_container_cluster_config.cluster_config.config_file_path
@@ -135,19 +135,19 @@ module "default_workload_egress" {
       "name" : "http2"
       "port" : "80"
       "targetPort" : "8000"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     },
     {
       "name" : "https"
       "port" : "443"
       "targetPort" : "443"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     },
     {
       "name" : "tcp"
       "port" : "5432"
       "targetPort" : "5432"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     }
   ]
   egress_autoscale_configuration = {
@@ -216,7 +216,7 @@ For all the configuration parameters details refer to the section below
 | <a name="input_egress_discovery_custom_configuration"></a> [egress\_discovery\_custom\_configuration](#input\_egress\_discovery\_custom\_configuration) | Map of key-value entries to set custom istio discovery labels. Default to null to autogenerate the labels according to var.istio\_mesh\_enrollment value. For more details about istio discovery configuration refer to https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html/installing/ossm-sidecar-injection#ossm-about-sidecar-injection_ossm-sidecar-injection and https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html/installing/ossm-deploying-multiple-service-meshes-on-single-cluster. | `map(string)` | `null` | no |
 | <a name="input_egress_internal_traffic_policy"></a> [egress\_internal\_traffic\_policy](#input\_egress\_internal\_traffic\_policy) | Internal traffic policy configuration for the egress. Allowed values are Cluster and Local. Default to Cluster. For more details refer to https://istio.io/latest/docs/tasks/security/authorization/authz-egress/. | `string` | `"Cluster"` | no |
 | <a name="input_egress_pdb_configuration"></a> [egress\_pdb\_configuration](#input\_egress\_pdb\_configuration) | Configuration of the PodDisruptionBudget for the istio egress definition. Default to null to leverage on Istio default configuration. | <pre>object({<br/>    minAvailable   = optional(string, null)<br/>    maxUnavailable = optional(string, null)<br/>  })</pre> | `null` | no |
-| <a name="input_egress_ports"></a> [egress\_ports](#input\_egress\_ports) | List of ports to configured on egress for outbound traffic. Default to port 443:443 on TCP. | <pre>list(object(<br/>    {<br/>      port : number,<br/>      name : string<br/>      proto : string,<br/>      targetPort : number<br/>    }<br/>  ))</pre> | <pre>[<br/>  {<br/>    "name": "https",<br/>    "port": 443,<br/>    "proto": "TCP",<br/>    "targetPort": 443<br/>  }<br/>]</pre> | no |
+| <a name="input_egress_ports"></a> [egress\_ports](#input\_egress\_ports) | List of ports to configured on egress for outbound traffic. Default to port 443:443 on TCP. | <pre>list(object(<br/>    {<br/>      port : number,<br/>      name : string<br/>      protocol : string,<br/>      targetPort : number<br/>    }<br/>  ))</pre> | <pre>[<br/>  {<br/>    "name": "https",<br/>    "port": 443,<br/>    "protocol": "TCP",<br/>    "targetPort": 443<br/>  }<br/>]</pre> | no |
 | <a name="input_egress_replicas"></a> [egress\_replicas](#input\_egress\_replicas) | Istio egress deployment replicaset configuration. If the var.egress\_autoscale\_configuration.enabled is true this value is ignored. Default to 3. | `number` | `3` | no |
 | <a name="input_egress_resources_configuration"></a> [egress\_resources\_configuration](#input\_egress\_resources\_configuration) | Istio egress resources deployment configuration. Default configuration is null and leverages on Istio default setting. | <pre>object(<br/>    {<br/>      limits : optional(object(<br/>        {<br/>          cpu : optional(string, null),<br/>          memory : optional(string, null)<br/>      }), null),<br/>      requests : optional(object(<br/>        {<br/>          cpu : optional(string, null)<br/>          memory : optional(string, null)<br/>      }), null)<br/>    }<br/>  )</pre> | `null` | no |
 | <a name="input_egress_selectors"></a> [egress\_selectors](#input\_egress\_selectors) | Istio egress selectors to route outbound egress traffic to the expected istio gateway and to the expected workload. Default to "app": "istio-egress" "istio": "istio-egress" "gateway-instance": "istio-egressgateway". Null not allowed | `map(string)` | <pre>{<br/>  "app": "istio-egress",<br/>  "istio": "istio-egress"<br/>}</pre> | no |

--- a/modules/sm-istio-egress/variables.tf
+++ b/modules/sm-istio-egress/variables.tf
@@ -100,14 +100,14 @@ variable "egress_ports" {
     {
       port : number,
       name : string
-      proto : string,
+      protocol : string,
       targetPort : number
     }
   ))
   default = [{
     port : 443,
     name : "https",
-    proto : "TCP",
+    protocol : "TCP",
     targetPort : 443
   }]
   description = "List of ports to configured on egress for outbound traffic. Default to port 443:443 on TCP."

--- a/modules/sm-istio-ingress/README.md
+++ b/modules/sm-istio-ingress/README.md
@@ -55,7 +55,7 @@ module "default_workload_ingress" {
       "name" : "http2"
       "port" : "80"
       "targetPort" : "8000"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     }
   ]
   cluster_config_file_path = data.ibm_container_cluster_config.cluster_config.config_file_path
@@ -136,13 +136,13 @@ module "default_workload_ingress" {
       "name" : "http2"
       "port" : "80"
       "targetPort" : "8000"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     },
     {
       "name" : "istio-health"
       "port" : "15021"
       "targetPort" : "15021"
-      "proto" : "TCP"
+      "protocol" : "TCP"
     }
   ]
   ingress_autoscale_configuration = {
@@ -228,7 +228,7 @@ For all the configuration parameters details refer to the section below
 | <a name="input_ingress_loadbalancer_type"></a> [ingress\_loadbalancer\_type](#input\_ingress\_loadbalancer\_type) | IBM Cloud LoadBalancer type bound to the ingress: valid values are "alb" for Application Load Balancer, "nlb" for Network Load Balancer, and "other" to define your LoadBalancer with your custom annotations. If var.ingress\_service\_type == "ClusterIP" this value hasn't effect. For more details refer to https://cloud.ibm.com/docs/vpc?topic=vpc-nlb-vs-elb. Default to ALB. | `string` | `"alb"` | no |
 | <a name="input_ingress_nlb_zones_subnets"></a> [ingress\_nlb\_zones\_subnets](#input\_ingress\_nlb\_zones\_subnets) | Map of tuples "subnetID": "VPC zone" to configure IBM Cloud Network LoadBalancer instances on the expected zone and subnet. Null value is not allowed. Default to empty map. | `map(string)` | `{}` | no |
 | <a name="input_ingress_pdb_configuration"></a> [ingress\_pdb\_configuration](#input\_ingress\_pdb\_configuration) | Configuration of the PodDisruptionBudget for the istio ingress definition. Default to null to leverage on Istio default configuration. | <pre>object({<br/>    minAvailable   = optional(string, null)<br/>    maxUnavailable = optional(string, null)<br/>  })</pre> | `null` | no |
-| <a name="input_ingress_ports"></a> [ingress\_ports](#input\_ingress\_ports) | List of ports to configured on ingress and LoadBalancer to list for inbound traffic. Default to port 443:8443 on TCP. | <pre>list(object(<br/>    {<br/>      port : number,<br/>      name : string<br/>      proto : string,<br/>      targetPort : number<br/>    }<br/>  ))</pre> | <pre>[<br/>  {<br/>    "name": "https",<br/>    "port": 443,<br/>    "proto": "TCP",<br/>    "targetPort": 8443<br/>  }<br/>]</pre> | no |
+| <a name="input_ingress_ports"></a> [ingress\_ports](#input\_ingress\_ports) | List of ports to configured on ingress and LoadBalancer to list for inbound traffic. Default to port 443:8443 on TCP. | <pre>list(object(<br/>    {<br/>      port : number,<br/>      name : string<br/>      protocol : string,<br/>      targetPort : number<br/>    }<br/>  ))</pre> | <pre>[<br/>  {<br/>    "name": "https",<br/>    "port": 443,<br/>    "protocol": "TCP",<br/>    "targetPort": 8443<br/>  }<br/>]</pre> | no |
 | <a name="input_ingress_proxy_protocol_allow_without"></a> [ingress\_proxy\_protocol\_allow\_without](#input\_ingress\_proxy\_protocol\_allow\_without) | Flag to support traffic with or without Proxy Protocol on ingress LoadBalancer (only ALB type) and on the EnvoyFilter that implements Proxy Protocol on ingress gateway | `bool` | `false` | no |
 | <a name="input_ingress_replicas"></a> [ingress\_replicas](#input\_ingress\_replicas) | Istio ingress deployment replicaset configuration. If the var.ingress\_autoscale\_configuration.enabled is true this value is ignored. Default to 3. | `number` | `3` | no |
 | <a name="input_ingress_resources_configuration"></a> [ingress\_resources\_configuration](#input\_ingress\_resources\_configuration) | Istio ingress resources deployment configuration. Default configuration is null and leverages on Istio default setting. | <pre>object(<br/>    {<br/>      limits : optional(object(<br/>        {<br/>          cpu : optional(string, null),<br/>          memory : optional(string, null)<br/>      }), null),<br/>      requests : optional(object(<br/>        {<br/>          cpu : optional(string, null)<br/>          memory : optional(string, null)<br/>      }), null)<br/>    }<br/>  )</pre> | `null` | no |

--- a/modules/sm-istio-ingress/README.md
+++ b/modules/sm-istio-ingress/README.md
@@ -252,3 +252,87 @@ For all the configuration parameters details refer to the section below
 | <a name="output_ingress_loadbalancer_ips"></a> [ingress\_loadbalancer\_ips](#output\_ingress\_loadbalancer\_ips) | Load balancer IP addresses. For NLB: returns map of service name to IP. For other types: returns map with indexed keys (ip-0, ip-1, etc). Returns empty map for ALB. |
 | <a name="output_istio_ingress_metadata"></a> [istio\_ingress\_metadata](#output\_istio\_ingress\_metadata) | Istio ingress helm release metadata |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Understanding Load Balancer Outputs
+
+The module outputs differ based on the `ingress_loadbalancer_type` configuration. This section explains the output format for each load balancer type.
+
+### Application Load Balancer (ALB)
+
+When `ingress_loadbalancer_type = "alb"`, a single Application Load Balancer is created and only the hostname is returned.
+
+**Input Configuration:**
+```hcl
+ingress_loadbalancer_type = "alb"
+ingress_alb_subnets = [
+  "0717-efe5c9b5-37e9-48c8-9d2e-a0a0a0a0a0a0",
+  "0727-b1f2c3d4-48e9-59d9-0e1f-b1b1b1b1b1b1",
+  "0737-c2g3d4e5-59f0-60e0-1f2g-c2c2c2c2c2c2"
+]
+```
+
+**Output Example:**
+```hcl
+ingress_loadbalancer_hostname = {
+  "public-ingress" = "04a736c5-us-south.lb.appdomain.cloud"
+}
+
+ingress_loadbalancer_ips = {}
+```
+
+### Network Load Balancer (NLB)
+
+When `ingress_loadbalancer_type = "nlb"`, one Network Load Balancer is created per zone specified in `ingress_nlb_zones_subnets`. Both hostnames and IP addresses are returned for each zone.
+
+**Input Configuration:**
+```hcl
+ingress_loadbalancer_type = "nlb"
+ingress_nlb_zones_subnets = {
+  "0717-efe5c9b5-37e9-48c8-9d2e-a0a0a0a0a0a0" = "us-south-1"
+  "0727-b1f2c3d4-48e9-59d9-0e1f-b1b1b1b1b1b1" = "us-south-2"
+  "0737-c2g3d4e5-59f0-60e0-1f2g-c2c2c2c2c2c2" = "us-south-3"
+}
+```
+
+**Output Example:**
+```hcl
+ingress_loadbalancer_hostname = {
+  "public-ingress-us-south-1" = "b363a563-us-south.lb.appdomain.cloud"
+  "public-ingress-us-south-2" = "e84cfa58-us-south.lb.appdomain.cloud"
+  "public-ingress-us-south-3" = "7185448c-us-south.lb.appdomain.cloud"
+}
+
+ingress_loadbalancer_ips = {
+  "public-ingress-us-south-1" = "52.118.188.140"
+  "public-ingress-us-south-2" = "52.118.205.19"
+  "public-ingress-us-south-3" = "52.118.102.88"
+}
+```
+
+### Custom Load Balancer (other)
+
+When `ingress_loadbalancer_type = "other"`, you provide custom annotations via `ingress_custom_annotations`. The module reserves IP addresses in each zone, but does not create hostnames. IPs are indexed sequentially.
+
+**Input Configuration:**
+```hcl
+ingress_loadbalancer_type = "other"
+ingress_custom_annotations = {
+  "service.kubernetes.io/ibm-load-balancer-cloud-provider-enable-features" = "service-dnlb"
+  "service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type"         = "private"
+  "service.kubernetes.io/ibm-load-balancer-cloud-provider-vpc-node-selector" = "transit"
+}
+```
+
+**Output Example:**
+```hcl
+ingress_loadbalancer_hostname = {}
+
+ingress_loadbalancer_ips = {
+  "ip-0" = "10.119.60.25"
+  "ip-1" = "10.12.129.159"
+  "ip-2" = "10.12.130.48"
+  "ip-3" = "10.51.208.41"
+}
+```
+
+**Note:** The number of IPs reserved corresponds to the number of zones used in the cluster. The IPs are not necessarily returned in zone order.

--- a/modules/sm-istio-ingress/README.md
+++ b/modules/sm-istio-ingress/README.md
@@ -203,7 +203,9 @@ For all the configuration parameters details refer to the section below
 | [helm_release.istio_ingress](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [null_resource.confirm_ingress_operational_alb](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.confirm_ingress_operational_nlb](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.confirm_ingress_operational_other](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [ibm_container_cluster_config.cluster_config](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/data-sources/container_cluster_config) | data source |
+| [kubernetes_service_v1.ingress_services](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/service_v1) | data source |
 
 ### Inputs
 
@@ -246,5 +248,7 @@ For all the configuration parameters details refer to the section below
 
 | Name | Description |
 |------|-------------|
-| <a name="output_istio_ingress_metadata"></a> [istio\_ingress\_metadata](#output\_istio\_ingress\_metadata) | istio\_ingress definition metadata |
+| <a name="output_ingress_loadbalancer_hostname"></a> [ingress\_loadbalancer\_hostname](#output\_ingress\_loadbalancer\_hostname) | Load balancer hostname(s). For ALB: returns map with single hostname. For NLB: returns map of service name to hostname per zone. For other types: returns empty map. |
+| <a name="output_ingress_loadbalancer_ips"></a> [ingress\_loadbalancer\_ips](#output\_ingress\_loadbalancer\_ips) | Load balancer IP addresses. For NLB: returns map of service name to IP. For other types: returns map with indexed keys (ip-0, ip-1, etc). Returns empty map for ALB. |
+| <a name="output_istio_ingress_metadata"></a> [istio\_ingress\_metadata](#output\_istio\_ingress\_metadata) | Istio ingress helm release metadata |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/sm-istio-ingress/main.tf
+++ b/modules/sm-istio-ingress/main.tf
@@ -244,12 +244,12 @@ locals {
   # For ALB/other: single service
   ingress_services_map = var.ingress_loadbalancer_type == "nlb" ? {
     for subnet_id, zone in var.ingress_nlb_zones_subnets :
-    "${var.namespace}/${local.prefix}${var.name}-${zone}" => {
+    "${local.prefix}${var.name}-${zone}" => {
       namespace = var.namespace
       service   = "${local.prefix}${var.name}-${zone}"
     }
     } : {
-    "${var.namespace}/${local.prefix}${var.name}" = {
+    "${local.prefix}${var.name}" = {
       namespace = var.namespace
       service   = "${local.prefix}${var.name}"
     }

--- a/modules/sm-istio-ingress/main.tf
+++ b/modules/sm-istio-ingress/main.tf
@@ -200,7 +200,7 @@ resource "null_resource" "confirm_ingress_operational_alb" {
   depends_on = [helm_release.istio_ingress]
   count      = var.ingress_loadbalancer_type == "alb" ? 1 : 0
   provisioner "local-exec" {
-    command     = "${path.module}/scripts/confirm-ingress-operational.sh \"${var.namespace}\" \"${local.prefix}${var.name}\""
+    command     = "${path.module}/scripts/confirm-ingress-operational.sh \"${var.namespace}\" \"${local.prefix}${var.name}\" \"alb\""
     interpreter = ["/bin/bash", "-c"]
     environment = {
       KUBECONFIG = data.ibm_container_cluster_config.cluster_config.config_file_path
@@ -208,15 +208,65 @@ resource "null_resource" "confirm_ingress_operational_alb" {
   }
 }
 
-# for nlb the ingress svc are created for each zone so there are a set of svc to check named "ingress-[svc name]-[zone]"
+# for nlb the ingress svc are created for each zone so there are a set of svc to check named "ingress-[svc name]-[zone]"
 resource "null_resource" "confirm_ingress_operational_nlb" {
   depends_on = [helm_release.istio_ingress]
   for_each   = var.ingress_loadbalancer_type == "nlb" ? var.ingress_nlb_zones_subnets : {}
   provisioner "local-exec" {
-    command     = "${path.module}/scripts/confirm-ingress-operational.sh \"${var.namespace}\" \"${local.prefix}${var.name}-${each.value}\""
+    command     = "${path.module}/scripts/confirm-ingress-operational.sh \"${var.namespace}\" \"${local.prefix}${var.name}-${each.value}\" \"nlb\""
     interpreter = ["/bin/bash", "-c"]
     environment = {
       KUBECONFIG = data.ibm_container_cluster_config.cluster_config.config_file_path
     }
+  }
+}
+
+# for other types (internal use) - single service with potentially multiple IPs
+resource "null_resource" "confirm_ingress_operational_other" {
+  depends_on = [helm_release.istio_ingress]
+  count      = var.ingress_loadbalancer_type == "other" ? 1 : 0
+  provisioner "local-exec" {
+    command     = "${path.module}/scripts/confirm-ingress-operational.sh \"${var.namespace}\" \"${local.prefix}${var.name}\" \"other\""
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      KUBECONFIG = data.ibm_container_cluster_config.cluster_config.config_file_path
+    }
+  }
+}
+
+##############################################################################
+# Lookup ingress service details
+##############################################################################
+
+locals {
+  # Build map of service names to query based on LB type
+  # For NLB: multiple services (one per zone)
+  # For ALB/other: single service
+  ingress_services_map = var.ingress_loadbalancer_type == "nlb" ? {
+    for subnet_id, zone in var.ingress_nlb_zones_subnets :
+    "${var.namespace}/${local.prefix}${var.name}-${zone}" => {
+      namespace = var.namespace
+      service   = "${local.prefix}${var.name}-${zone}"
+    }
+    } : {
+    "${var.namespace}/${local.prefix}${var.name}" = {
+      namespace = var.namespace
+      service   = "${local.prefix}${var.name}"
+    }
+  }
+}
+
+# Query all ingress services (works for ALB, NLB, and other types)
+data "kubernetes_service_v1" "ingress_services" {
+  depends_on = [
+    null_resource.confirm_ingress_operational_alb,
+    null_resource.confirm_ingress_operational_nlb,
+    null_resource.confirm_ingress_operational_other
+  ]
+  for_each = local.ingress_services_map
+
+  metadata {
+    name      = each.value.service
+    namespace = each.value.namespace
   }
 }

--- a/modules/sm-istio-ingress/outputs.tf
+++ b/modules/sm-istio-ingress/outputs.tf
@@ -1,4 +1,25 @@
 output "istio_ingress_metadata" {
-  description = "istio_ingress definition metadata"
+  description = "Istio ingress helm release metadata"
   value       = helm_release.istio_ingress.metadata
+}
+
+output "ingress_loadbalancer_hostname" {
+  description = "Load balancer hostname(s). For ALB: returns map with single hostname. For NLB: returns map of service name to hostname per zone. For other types: returns empty map."
+  value = var.ingress_loadbalancer_type != "other" ? {
+    for k, v in data.kubernetes_service_v1.ingress_services :
+    split("/", k)[1] => try(v.status[0].load_balancer[0].ingress[0].hostname, null)
+  } : {}
+}
+
+output "ingress_loadbalancer_ips" {
+  description = "Load balancer IP addresses. For NLB: returns map of service name to IP. For other types: returns map with indexed keys (ip-0, ip-1, etc). Returns empty map for ALB."
+  value = var.ingress_loadbalancer_type == "nlb" ? {
+    for k, v in data.kubernetes_service_v1.ingress_services :
+    split("/", k)[1] => try(v.status[0].load_balancer[0].ingress[0].ip, null)
+    } : var.ingress_loadbalancer_type == "other" && length(data.kubernetes_service_v1.ingress_services) > 0 ? {
+    for idx, ip in try(
+      data.kubernetes_service_v1.ingress_services["${var.namespace}/${local.prefix}${var.name}"].status[0].load_balancer[0].ingress[*].ip,
+      []
+    ) : "ip-${idx}" => ip
+  } : {}
 }

--- a/modules/sm-istio-ingress/outputs.tf
+++ b/modules/sm-istio-ingress/outputs.tf
@@ -7,7 +7,7 @@ output "ingress_loadbalancer_hostname" {
   description = "Load balancer hostname(s). For ALB: returns map with single hostname. For NLB: returns map of service name to hostname per zone. For other types: returns empty map."
   value = var.ingress_loadbalancer_type != "other" ? {
     for k, v in data.kubernetes_service_v1.ingress_services :
-    split("/", k)[1] => try(v.status[0].load_balancer[0].ingress[0].hostname, null)
+    k => try(v.status[0].load_balancer[0].ingress[0].hostname, null)
   } : {}
 }
 
@@ -15,10 +15,10 @@ output "ingress_loadbalancer_ips" {
   description = "Load balancer IP addresses. For NLB: returns map of service name to IP. For other types: returns map with indexed keys (ip-0, ip-1, etc). Returns empty map for ALB."
   value = var.ingress_loadbalancer_type == "nlb" ? {
     for k, v in data.kubernetes_service_v1.ingress_services :
-    split("/", k)[1] => try(v.status[0].load_balancer[0].ingress[0].ip, null)
+    k => try(v.status[0].load_balancer[0].ingress[0].ip, null)
     } : var.ingress_loadbalancer_type == "other" && length(data.kubernetes_service_v1.ingress_services) > 0 ? {
     for idx, ip in try(
-      data.kubernetes_service_v1.ingress_services["${var.namespace}/${local.prefix}${var.name}"].status[0].load_balancer[0].ingress[*].ip,
+      data.kubernetes_service_v1.ingress_services["${local.prefix}${var.name}"].status[0].load_balancer[0].ingress[*].ip,
       []
     ) : "ip-${idx}" => ip
   } : {}

--- a/modules/sm-istio-ingress/scripts/confirm-ingress-operational.sh
+++ b/modules/sm-istio-ingress/scripts/confirm-ingress-operational.sh
@@ -6,6 +6,7 @@ set -e
 
 namespace="${1}"
 service="${2}"
+lb_type="${3:-alb}"
 fail=false
 initialsleep=15
 
@@ -14,7 +15,7 @@ if [[ -z "${service}" ]]; then
   service="istio-ingressgateway"
 fi
 
-echo "Checking ingress gateway ${service} successful deployment in namespace ${namespace}"
+echo "Checking ingress gateway ${service} successful deployment in namespace ${namespace} for load balancer type ${lb_type}"
 
 echo "Initial sleep of ${initialsleep} seconds before starting to check"
 sleep "${initialsleep}"
@@ -22,7 +23,7 @@ sleep "${initialsleep}"
 echo "Checking deployments ${service} in namespace ${namespace}"
 
 DEPLOYMENTS=()
-while IFS='' read -r line; do DEPLOYMENTS+=("$line"); done < <(kubectl get deployment "${service}" -n "${namespace}" --no-headers | cut -f1 -d ' ')
+while IFS='' read -r line; do DEPLOYMENTS+=("$line"); done < <(kubectl get deployment "${service}" -n "${namespace}" --no-headers 2>/dev/null | cut -f1 -d ' ' || true)
 
 # Wait for all deployments to come up - timeout after 5 mins
 # shellcheck disable=SC2068
@@ -35,43 +36,64 @@ for dep in ${DEPLOYMENTS[@]}; do
 done
 
 
-# Ensure the load balancer hostname is set
+# Ensure the load balancer is ready based on type
 counter=0
 sleeptime=30
-retries=60 # 60 x 30 = 1800 secs = 30 mins
-ext_hostname=""
-while [ -z "${ext_hostname}" ]; do
-  # Get the hostname from the kube service (retry needed on service lookup, as sometimes service may not exist yet)
-  attempts=20 # 20 x 30 = 600 secs = 10 mins
-  n=0
-  until [ "$n" -ge $attempts ]; do
-    ext_hostname=$(kubectl get svc "${service}" -n "${namespace}" --template="{{range .status.loadBalancer.ingress}}{{.hostname}}{{end}}") && break
-    n=$((n+1))
-    if [ "$n" = $attempts ]; then
-      echo "Maximum attempts reached for gateway ${service} in namespace ${namespace}. Giving up!"
-      exit 1
-    else
-      echo "Retrying in ${sleeptime} secs .."
-      sleep "${sleeptime}"
-    fi
-  done
+max_retries=60  # 60 x 30 = 1800 secs = 30 mins
+lb_ready=false
 
-  # If not set yet, retry
-  if [ -z "${ext_hostname}" ]; then
-    # Give up when number of retries are reached
-    if [ ${counter} == ${retries} ]; then
-      echo "ERROR: Unable to detect external hostname for ${service} in namespace ${namespace}"
+echo "Waiting for load balancer to be assigned (type: ${lb_type})..."
+
+while [ ${counter} -lt ${max_retries} ]; do
+  # Check based on load balancer type
+  case "${lb_type}" in
+    alb)
+      # For ALB, check for hostname
+      lb_value=$(kubectl get svc "${service}" -n "${namespace}" --template="{{range .status.loadBalancer.ingress}}{{.hostname}}{{end}}" 2>/dev/null || echo "")
+      if [ -n "${lb_value}" ]; then
+        echo "Ingress gateway ${service} in namespace ${namespace} assigned with hostname: ${lb_value}"
+        lb_ready=true
+      fi
+      ;;
+    nlb)
+      # For NLB, check for IP
+      lb_value=$(kubectl get svc "${service}" -n "${namespace}" --template="{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}" 2>/dev/null || echo "")
+      if [ -n "${lb_value}" ]; then
+        echo "Ingress gateway ${service} in namespace ${namespace} assigned with IP: ${lb_value}"
+        lb_ready=true
+      fi
+      ;;
+    other)
+      # For other types, check for one or more IPs
+      ingress_count=$(kubectl get svc "${service}" -n "${namespace}" -o json 2>/dev/null | jq -r '.status.loadBalancer.ingress | length' 2>/dev/null || echo "0")
+      if [ "${ingress_count}" -gt 0 ]; then
+        lb_ips=$(kubectl get svc "${service}" -n "${namespace}" -o json 2>/dev/null | jq -r '.status.loadBalancer.ingress[].ip' 2>/dev/null | tr '\n' ' ' || echo "")
+        echo "Ingress gateway ${service} in namespace ${namespace} assigned with ${ingress_count} IP(s): ${lb_ips}"
+        lb_ready=true
+      fi
+      ;;
+    *)
+      echo "ERROR: Unknown load balancer type: ${lb_type}"
       fail=true
       break
-    fi
-    counter=$((counter+1))
-    sleep "${sleeptime}"
-  else
-    # break the loop if hostname value detected
-    echo "istio gateway ${service} in namespace ${namespace} assigned with hostname: ${ext_hostname}"
-    # TODO: Add some health checks against the LB
+      ;;
+  esac
+
+  # If ready, break out of loop
+  if [ "${lb_ready}" = true ]; then
     break
   fi
+
+  # Increment counter and check if max retries reached
+  counter=$((counter+1))
+  if [ ${counter} -eq ${max_retries} ]; then
+    echo "ERROR: Unable to detect load balancer details for ${service} in namespace ${namespace} (type: ${lb_type}) after ${max_retries} attempts"
+    fail=true
+    break
+  fi
+
+  echo "Attempt ${counter}/${max_retries}: Load balancer not ready yet, retrying in ${sleeptime} secs..."
+  sleep "${sleeptime}"
 done
 
 # Fail with some debug prints if issues detected
@@ -79,9 +101,10 @@ if [ ${fail} == true ]; then
   echo "Problem detected with gateway ${service} in namespace ${namespace}. Printing some debug info.."
   set +e
   kubectl get svc -n "${namespace}" -o wide
-  kubectl get deployment "${service}" -n "${namespace}" -o wide
+  kubectl get deployment "${service}" -n "${namespace}" -o wide 2>/dev/null || echo "No deployment found"
   kubectl get pods -n "${namespace}" -o wide
   kubectl describe svc "${service}" -n "${namespace}"
-  kubectl describe svc "${service}" -n "${namespace}"
-  # exit 1
+  exit 1
 fi
+
+echo "Ingress gateway ${service} in namespace ${namespace} is operational"

--- a/modules/sm-istio-ingress/variables.tf
+++ b/modules/sm-istio-ingress/variables.tf
@@ -169,14 +169,14 @@ variable "ingress_ports" {
     {
       port : number,
       name : string
-      proto : string,
+      protocol : string,
       targetPort : number
     }
   ))
   default = [{
     port : 443,
     name : "https",
-    proto : "TCP",
+    protocol : "TCP",
     targetPort : 8443
   }]
   description = "List of ports to configured on ingress and LoadBalancer to list for inbound traffic. Default to port 443:8443 on TCP."


### PR DESCRIPTION
### Description

Ingress module now returns in output info about loadbalancer hostnames and IPs according to the type of the LB deployed.  The output is formatted as a map with key the name of the ingress and the values the hostnames or the IPs. This is needed to support NLB deployment which creates multiple hostnames in different zones.
`proto` attribute of `ingress_ports` variable is renamed to `protocol` for consistency purpose.

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Ingress module now returns in output info about loadbalancer hostnames and IPs according to the type of the LB deployed

`proto` attribute of `ingress_ports` variable in ingress and egress submodules is replaced with `protocol` to maintain consistency with service mesh v2. This will result in an update in `helm_release` terraform resource but underlying `values.yaml` and `templates` of the chart will not get affected. So even though a fresh terraform plan will show changes it will not recreate/destroy any resources. It will just update the terraform resource in statefile.

This is how the terraform plan will look both for istio_ingress and istio_egress. However terraform apply will not make any change to actual helm chart here as underlying template remains the same.
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.basic_workload_ingress.helm_release.istio_ingress will be updated in-place
  ~ resource "helm_release" "istio_ingress" {
      ~ id                         = "alb-ingress-alb-ingress" -> (known after apply)
      ~ metadata                   = {
          ~ app_version    = "0.0.1" -> (known after apply)
          ~ chart          = "istio-ingress" -> (known after apply)
          ~ first_deployed = 1777888166 -> (known after apply)
          ~ last_deployed  = 1777888166 -> (known after apply)
          ~ name           = "alb-ingress-alb-ingress" -> (known after apply)
          ~ namespace      = "alb-ingress" -> (known after apply)
          + notes          = (known after apply)
          ~ revision       = 1 -> (known after apply)
          ~ values         = jsonencode(
                {
                  - ingress = {
                      - affinity                      = {
                          - nodeAffinity    = null
                          - podAffinity     = null
                          - podAntiAffinity = null
                        }

```

```
          ~ <<-EOT
                "ingress":
                  "ports":
                  - "name": "http2"
                    "port": 80
              -     "proto": "TCP"
              +     "protocol": "TCP"
                    "targetPort": 8000
```

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
