### PR TITLE
Ingress svc output fix

### DIFF
--- a/chart/istio-egress/templates/deployment.yaml
+++ b/chart/istio-egress/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.egress.createDeployment false -}}
+{{- if ne (.Values.egress).createDeployment false -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/istio-egress/templates/deployment.yaml
+++ b/chart/istio-egress/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.egress).createDeployment | default true -}}
+{{- if ne .Values.egress.createDeployment false -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/istio-egress/templates/sa.yaml
+++ b/chart/istio-egress/templates/sa.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.egress.createServiceAccount false -}}
+{{- if ne (.Values.egress).createServiceAccount false -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/chart/istio-egress/templates/sa.yaml
+++ b/chart/istio-egress/templates/sa.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.egress).createServiceAccount | default true -}}
+{{- if ne .Values.egress.createServiceAccount false -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/chart/istio-egress/templates/svc.yaml
+++ b/chart/istio-egress/templates/svc.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.egress).createService | default true -}}
+{{- if ne .Values.egress.createService false -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/chart/istio-egress/templates/svc.yaml
+++ b/chart/istio-egress/templates/svc.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.egress.createService false -}}
+{{- if ne (.Values.egress).createService false -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/chart/istio-ingress/templates/albdeployment.yaml
+++ b/chart/istio-ingress/templates/albdeployment.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.ingress.createDeployment false -}}
+{{- if ne (.Values.ingress).createDeployment false -}}
 {{- if or (eq .Values.ingress.lbtype "alb") (eq .Values.ingress.lbtype "other") }}
 apiVersion: apps/v1
 kind: Deployment

--- a/chart/istio-ingress/templates/albdeployment.yaml
+++ b/chart/istio-ingress/templates/albdeployment.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.ingress).createDeployment | default true -}}
+{{- if ne .Values.ingress.createDeployment false -}}
 {{- if or (eq .Values.ingress.lbtype "alb") (eq .Values.ingress.lbtype "other") }}
 apiVersion: apps/v1
 kind: Deployment

--- a/chart/istio-ingress/templates/albsvc.yaml
+++ b/chart/istio-ingress/templates/albsvc.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.ingress).createService | default true -}}
+{{- if ne .Values.ingress.createService false -}}
 {{- if or (eq .Values.ingress.lbtype "alb") }}
 apiVersion: v1
 kind: Service

--- a/chart/istio-ingress/templates/albsvc.yaml
+++ b/chart/istio-ingress/templates/albsvc.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.ingress.createService false -}}
+{{- if ne (.Values.ingress).createService false -}}
 {{- if or (eq .Values.ingress.lbtype "alb") }}
 apiVersion: v1
 kind: Service

--- a/chart/istio-ingress/templates/genericsvc.yaml
+++ b/chart/istio-ingress/templates/genericsvc.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.ingress).createService | default true -}}
+{{- if ne .Values.ingress.createService false -}}
 {{- if and (eq .Values.ingress.lbtype "other") .Values.ingress.customAnnotations }}
 apiVersion: v1
 kind: Service

--- a/chart/istio-ingress/templates/genericsvc.yaml
+++ b/chart/istio-ingress/templates/genericsvc.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.ingress.createService false -}}
+{{- if ne (.Values.ingress).createService false -}}
 {{- if and (eq .Values.ingress.lbtype "other") .Values.ingress.customAnnotations }}
 apiVersion: v1
 kind: Service

--- a/chart/istio-ingress/templates/nlbdeployment.yaml
+++ b/chart/istio-ingress/templates/nlbdeployment.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.ingress).createDeployment | default true -}}
+{{- if ne .Values.ingress.createDeployment false -}}
 {{- if (eq .Values.ingress.lbtype "nlb") }}
 {{- range $lb_subnet, $lb_subnet_zone := .Values.ingress.nlbzonessubnets }}
 apiVersion: apps/v1

--- a/chart/istio-ingress/templates/nlbdeployment.yaml
+++ b/chart/istio-ingress/templates/nlbdeployment.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.ingress.createDeployment false -}}
+{{- if ne (.Values.ingress).createDeployment false -}}
 {{- if (eq .Values.ingress.lbtype "nlb") }}
 {{- range $lb_subnet, $lb_subnet_zone := .Values.ingress.nlbzonessubnets }}
 apiVersion: apps/v1

--- a/chart/istio-ingress/templates/nlbsvc.yaml
+++ b/chart/istio-ingress/templates/nlbsvc.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.ingress.createService false -}}
+{{- if ne (.Values.ingress).createService false -}}
 {{- if (eq .Values.ingress.lbtype "nlb") }}
 {{- range $lb_subnet, $lb_subnet_zone := .Values.ingress.nlbzonessubnets }}
 apiVersion: v1

--- a/chart/istio-ingress/templates/nlbsvc.yaml
+++ b/chart/istio-ingress/templates/nlbsvc.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.ingress).createService | default true -}}
+{{- if ne .Values.ingress.createService false -}}
 {{- if (eq .Values.ingress.lbtype "nlb") }}
 {{- range $lb_subnet, $lb_subnet_zone := .Values.ingress.nlbzonessubnets }}
 apiVersion: v1

--- a/chart/istio-ingress/templates/sa.yaml
+++ b/chart/istio-ingress/templates/sa.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.ingress.createServiceAccount false -}}
+{{- if ne (.Values.ingress).createServiceAccount false -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/chart/istio-ingress/templates/sa.yaml
+++ b/chart/istio-ingress/templates/sa.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.ingress).createServiceAccount | default true -}}
+{{- if ne .Values.ingress.createServiceAccount false -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/modules/sm-istio-egress/main.tf
+++ b/modules/sm-istio-egress/main.tf
@@ -212,6 +212,8 @@ resource "helm_release" "istio_egress" {
 }
 
 resource "null_resource" "confirm_egress_operational" {
+
+  count = var.egress_create_service ? 1 : 0
   depends_on = [helm_release.istio_egress]
   triggers = {
     helm_revision = helm_release.istio_egress.metadata.revision

--- a/modules/sm-istio-egress/main.tf
+++ b/modules/sm-istio-egress/main.tf
@@ -4,6 +4,11 @@ locals {
   istio_egress_release_name = "${var.namespace}-${var.name}"
   istio_egress_chart_path   = "istio-egress"
 
+  service_name = (
+    var.egress_service_name != null &&
+    trimspace(var.egress_service_name) != ""
+  ) ? var.egress_service_name : var.name
+
   egress_discovery_configuration = var.egress_discovery_custom_configuration != null ? var.egress_discovery_custom_configuration : (
     var.istio_mesh_enrollment == "default" ? {
       "istio-discovery" : "enabled",
@@ -208,8 +213,11 @@ resource "helm_release" "istio_egress" {
 
 resource "null_resource" "confirm_egress_operational" {
   depends_on = [helm_release.istio_egress]
+  triggers = {
+    helm_revision = helm_release.istio_egress.metadata.revision
+  }
   provisioner "local-exec" {
-    command     = "${path.module}/scripts/confirm-egress-operational.sh \"${var.namespace}\" \"${local.prefix}${var.name}\""
+    command     = "${path.module}/scripts/confirm-egress-operational.sh \"${var.namespace}\" \"${local.prefix}${local.service_name}\""
     interpreter = ["/bin/bash", "-c"]
     environment = {
       KUBECONFIG = data.ibm_container_cluster_config.cluster_config.config_file_path

--- a/modules/sm-istio-egress/main.tf
+++ b/modules/sm-istio-egress/main.tf
@@ -213,7 +213,7 @@ resource "helm_release" "istio_egress" {
 
 resource "null_resource" "confirm_egress_operational" {
 
-  count = var.egress_create_service ? 1 : 0
+  count      = var.egress_create_service ? 1 : 0
   depends_on = [helm_release.istio_egress]
   triggers = {
     helm_revision = helm_release.istio_egress.metadata.revision

--- a/modules/sm-istio-ingress/main.tf
+++ b/modules/sm-istio-ingress/main.tf
@@ -3,6 +3,11 @@ locals {
   istio_ingress_release_name = "${var.namespace}-${var.name}"
   istio_ingress_chart_path   = "istio-ingress"
 
+  service_name = (
+    var.ingress_service_name != null &&
+    trimspace(var.ingress_service_name) != ""
+  ) ? var.ingress_service_name : var.name
+
   ingress_discovery_configuration = var.ingress_discovery_custom_configuration != null ? var.ingress_discovery_custom_configuration : (
     var.istio_mesh_enrollment == "default" ? {
       "istio-discovery" : "enabled",
@@ -265,9 +270,12 @@ resource "helm_release" "istio_ingress" {
 
 resource "null_resource" "confirm_ingress_operational_alb" {
   depends_on = [helm_release.istio_ingress]
-  count      = var.ingress_loadbalancer_type == "alb" ? 1 : 0
+  triggers = {
+    helm_revision = helm_release.istio_ingress.metadata.revision
+  }
+  count = var.ingress_loadbalancer_type == "alb" && var.ingress_create_service == true ? 1 : 0
   provisioner "local-exec" {
-    command     = "${path.module}/scripts/confirm-ingress-operational.sh \"${var.namespace}\" \"${local.prefix}${var.name}\" \"alb\""
+    command     = "${path.module}/scripts/confirm-ingress-operational.sh \"${var.namespace}\" \"${local.prefix}${local.service_name}\" \"alb\""
     interpreter = ["/bin/bash", "-c"]
     environment = {
       KUBECONFIG = data.ibm_container_cluster_config.cluster_config.config_file_path
@@ -278,9 +286,13 @@ resource "null_resource" "confirm_ingress_operational_alb" {
 # for nlb the ingress svc are created for each zone so there are a set of svc to check named "ingress-[svc name]-[zone]"
 resource "null_resource" "confirm_ingress_operational_nlb" {
   depends_on = [helm_release.istio_ingress]
-  for_each   = var.ingress_loadbalancer_type == "nlb" ? var.ingress_nlb_zones_subnets : {}
+
+  triggers = {
+    helm_revision = helm_release.istio_ingress.metadata.revision
+  }
+  for_each = var.ingress_loadbalancer_type == "nlb" && var.ingress_create_service == true ? var.ingress_nlb_zones_subnets : {}
   provisioner "local-exec" {
-    command     = "${path.module}/scripts/confirm-ingress-operational.sh \"${var.namespace}\" \"${local.prefix}${var.name}-${each.value}\" \"nlb\""
+    command     = "${path.module}/scripts/confirm-ingress-operational.sh \"${var.namespace}\" \"${local.prefix}${local.service_name}-${each.value}\" \"nlb\""
     interpreter = ["/bin/bash", "-c"]
     environment = {
       KUBECONFIG = data.ibm_container_cluster_config.cluster_config.config_file_path
@@ -291,9 +303,13 @@ resource "null_resource" "confirm_ingress_operational_nlb" {
 # for other types (internal use) - single service with potentially multiple IPs
 resource "null_resource" "confirm_ingress_operational_other" {
   depends_on = [helm_release.istio_ingress]
-  count      = var.ingress_loadbalancer_type == "other" ? 1 : 0
+
+  triggers = {
+    helm_revision = helm_release.istio_ingress.metadata.revision
+  }
+  count = var.ingress_loadbalancer_type == "other" && var.ingress_create_service == true ? 1 : 0
   provisioner "local-exec" {
-    command     = "${path.module}/scripts/confirm-ingress-operational.sh \"${var.namespace}\" \"${local.prefix}${var.name}\" \"other\""
+    command     = "${path.module}/scripts/confirm-ingress-operational.sh \"${var.namespace}\" \"${local.prefix}${local.service_name}\" \"other\""
     interpreter = ["/bin/bash", "-c"]
     environment = {
       KUBECONFIG = data.ibm_container_cluster_config.cluster_config.config_file_path
@@ -309,18 +325,21 @@ locals {
   # Build map of service names to query based on LB type
   # For NLB: multiple services (one per zone)
   # For ALB/other: single service
-  ingress_services_map = var.ingress_loadbalancer_type == "nlb" ? {
-    for subnet_id, zone in var.ingress_nlb_zones_subnets :
-    "${local.prefix}${var.name}-${zone}" => {
-      namespace = var.namespace
-      service   = "${local.prefix}${var.name}-${zone}"
+
+  ingress_services_map = var.ingress_create_service ? (
+    var.ingress_loadbalancer_type == "nlb" ? {
+      for subnet_id, zone in var.ingress_nlb_zones_subnets :
+      "${local.prefix}${local.service_name}-${zone}" => {
+        namespace = var.namespace
+        service   = "${local.prefix}${local.service_name}-${zone}"
+      }
+      } : {
+      "${local.prefix}${local.service_name}" = {
+        namespace = var.namespace
+        service   = "${local.prefix}${local.service_name}"
+      }
     }
-    } : {
-    "${local.prefix}${var.name}" = {
-      namespace = var.namespace
-      service   = "${local.prefix}${var.name}"
-    }
-  }
+  ) : {}
 }
 
 # Query all ingress services (works for ALB, NLB, and other types)

--- a/modules/sm-istio-ingress/outputs.tf
+++ b/modules/sm-istio-ingress/outputs.tf
@@ -18,7 +18,7 @@ output "ingress_loadbalancer_ips" {
     k => try(v.status[0].load_balancer[0].ingress[0].ip, null)
     } : var.ingress_loadbalancer_type == "other" && length(data.kubernetes_service_v1.ingress_services) > 0 ? {
     for idx, ip in try(
-      data.kubernetes_service_v1.ingress_services["${local.prefix}${var.name}"].status[0].load_balancer[0].ingress[*].ip,
+      data.kubernetes_service_v1.ingress_services["${local.prefix}${local.service_name}"].status[0].load_balancer[0].ingress[*].ip,
       []
     ) : "ip-${idx}" => ip
   } : {}


### PR DESCRIPTION
### Description

Template is not able to disable service, deployment and serviceaccount currently. Also needed some changes to ingress loadBalancer outputs because of change in service name input variable addition.

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Fix helm chart code to disable single resources
Fix on ingress loadbalancer output

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
