### PR TITLE
feat: add configurable service account names for ingress and egress

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-19T06:39:28Z",
+  "generated_at": "2026-06-25T10:05:32Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "ff9ee043d85595eb255c05dfe32ece02a53efbb2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 126,
+        "line_number": 125,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ https://terraform-ibm-modules.github.io/documentation/#/implementation-guideline
 -->
 <!-- ## Reference architectures -->
 
-
 <!-- Replace this heading with the name of the root level module (the repo name) -->
 ## terraform-ibm-ocp-service-mesh
 

--- a/chart/istio-egress/templates/sa.yaml
+++ b/chart/istio-egress/templates/sa.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.egress.name }}-service-account
+  name: {{ .Values.egress.serviceAccountName }}
   namespace: {{ .Values.egress.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -26,5 +26,5 @@ roleRef:
   name: {{ .Values.egress.name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.egress.name }}-service-account
+  name: {{ .Values.egress.serviceAccountName }}
 {{- end }}

--- a/chart/istio-egress/values.yaml
+++ b/chart/istio-egress/values.yaml
@@ -5,6 +5,7 @@ egress:
   createService: true
   serviceName: null
   createServiceAccount: true
+  serviceAccountName: null
   namespace: istio-system
   istioMeshEnrollment:
   istioNamespaceEnrollmentLabels: {}

--- a/chart/istio-ingress/templates/sa.yaml
+++ b/chart/istio-ingress/templates/sa.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.ingress.name }}-service-account
+  name: {{ .Values.ingress.serviceAccountName }}
   namespace: {{ .Values.ingress.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -26,5 +26,5 @@ roleRef:
   name: {{ .Values.ingress.name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.ingress.name }}-service-account
+  name: {{ .Values.ingress.serviceAccountName }}
 {{- end }}

--- a/chart/istio-ingress/values.yaml
+++ b/chart/istio-ingress/values.yaml
@@ -5,6 +5,7 @@ ingress:
   createService: true
   serviceName: null
   createServiceAccount: true
+  serviceAccountName: null
   namespace: istio-system
   istioMeshEnrollment:
   proxyProtocol:

--- a/modules/sm-istio-egress/README.md
+++ b/modules/sm-istio-egress/README.md
@@ -183,7 +183,7 @@ For all the configuration parameters details refer to the section below
 ### Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0.0, <4.0.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.59.0, < 3.0.0 |
@@ -193,13 +193,13 @@ For all the configuration parameters details refer to the section below
 ### Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_egress_namespace"></a> [egress\_namespace](#module\_egress\_namespace) | terraform-ibm-modules/namespace/ibm | v2.0.1 |
 
 ### Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [helm_release.istio_egress](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_annotations.istio_namespace_annotations](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/annotations) | resource |
 | [kubernetes_labels.istio_namespace_labels](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/labels) | resource |
@@ -209,7 +209,7 @@ For all the configuration parameters details refer to the section below
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_add_istio_labels_annotations_to_existing_namespace"></a> [add\_istio\_labels\_annotations\_to\_existing\_namespace](#input\_add\_istio\_labels\_annotations\_to\_existing\_namespace) | Flag to add istio labels and annotations like the discovery ones or the value of var.egress\_discovery\_custom\_configuration to an existing namespace. Default to false. If var.create\_namespace is true this flag is ignored. | `bool` | `false` | no |
 | <a name="input_cluster_config_endpoint_type"></a> [cluster\_config\_endpoint\_type](#input\_cluster\_config\_endpoint\_type) | Specify which type of endpoint to use for for cluster config access: 'default', 'private', 'vpe', 'link'. 'default' value will use the default endpoint of the cluster. | `string` | `"default"` | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Id of the target IBM Cloud OpenShift Cluster | `string` | n/a | yes |
@@ -246,6 +246,6 @@ For all the configuration parameters details refer to the section below
 ### Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_istio_egress_metadata"></a> [istio\_egress\_metadata](#output\_istio\_egress\_metadata) | istio\_egress definition metadata |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/sm-istio-egress/README.md
+++ b/modules/sm-istio-egress/README.md
@@ -183,7 +183,7 @@ For all the configuration parameters details refer to the section below
 ### Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0.0, <4.0.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.59.0, < 3.0.0 |
@@ -193,13 +193,13 @@ For all the configuration parameters details refer to the section below
 ### Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_egress_namespace"></a> [egress\_namespace](#module\_egress\_namespace) | terraform-ibm-modules/namespace/ibm | v2.0.1 |
 
 ### Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [helm_release.istio_egress](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_annotations.istio_namespace_annotations](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/annotations) | resource |
 | [kubernetes_labels.istio_namespace_labels](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/labels) | resource |
@@ -209,7 +209,7 @@ For all the configuration parameters details refer to the section below
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_add_istio_labels_annotations_to_existing_namespace"></a> [add\_istio\_labels\_annotations\_to\_existing\_namespace](#input\_add\_istio\_labels\_annotations\_to\_existing\_namespace) | Flag to add istio labels and annotations like the discovery ones or the value of var.egress\_discovery\_custom\_configuration to an existing namespace. Default to false. If var.create\_namespace is true this flag is ignored. | `bool` | `false` | no |
 | <a name="input_cluster_config_endpoint_type"></a> [cluster\_config\_endpoint\_type](#input\_cluster\_config\_endpoint\_type) | Specify which type of endpoint to use for for cluster config access: 'default', 'private', 'vpe', 'link'. 'default' value will use the default endpoint of the cluster. | `string` | `"default"` | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Id of the target IBM Cloud OpenShift Cluster | `string` | n/a | yes |
@@ -229,6 +229,7 @@ For all the configuration parameters details refer to the section below
 | <a name="input_egress_replicas"></a> [egress\_replicas](#input\_egress\_replicas) | Istio egress deployment replicaset configuration. If the var.egress\_autoscale\_configuration.enabled is true this value is ignored. Default to 3. | `number` | `3` | no |
 | <a name="input_egress_resources_configuration"></a> [egress\_resources\_configuration](#input\_egress\_resources\_configuration) | Istio egress resources deployment configuration. Default configuration is null and leverages on Istio default setting. | <pre>object(<br/>    {<br/>      limits : optional(object(<br/>        {<br/>          cpu : optional(string, null),<br/>          memory : optional(string, null)<br/>      }), null),<br/>      requests : optional(object(<br/>        {<br/>          cpu : optional(string, null)<br/>          memory : optional(string, null)<br/>      }), null)<br/>    }<br/>  )</pre> | `null` | no |
 | <a name="input_egress_selectors"></a> [egress\_selectors](#input\_egress\_selectors) | Istio egress selectors to route outbound egress traffic to the expected istio gateway and to the expected workload. Default to "app": "istio-egress" "istio": "istio-egress" "gateway-instance": "istio-egressgateway". Null not allowed | `map(string)` | <pre>{<br/>  "app": "istio-egress",<br/>  "istio": "istio-egress"<br/>}</pre> | no |
+| <a name="input_egress_service_account_name"></a> [egress\_service\_account\_name](#input\_egress\_service\_account\_name) | Optional override for the egress ServiceAccount name. If null or empty, defaults to '<egress.name>-service-account'. | `string` | `null` | no |
 | <a name="input_egress_service_name"></a> [egress\_service\_name](#input\_egress\_service\_name) | Optional override for the egress Service name. If null or empty, the value of var.name is used as default. | `string` | `null` | no |
 | <a name="input_egress_termination_grace_period"></a> [egress\_termination\_grace\_period](#input\_egress\_termination\_grace\_period) | Number of seconds for the Istio egress deployment for the grace period before terminating the pods and dropping the connections. Default to null to leverage on Istio default. | `number` | `null` | no |
 | <a name="input_egress_tolerations"></a> [egress\_tolerations](#input\_egress\_tolerations) | Istio egress tolerations configuration. Default to tolerate 'dedicated: edge' taint. For more details # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#toleration-v1-core | `list(any)` | `[]` | no |
@@ -245,6 +246,6 @@ For all the configuration parameters details refer to the section below
 ### Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_istio_egress_metadata"></a> [istio\_egress\_metadata](#output\_istio\_egress\_metadata) | istio\_egress definition metadata |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/sm-istio-egress/main.tf
+++ b/modules/sm-istio-egress/main.tf
@@ -193,6 +193,11 @@ resource "helm_release" "istio_egress" {
       type  = "string"
       value = var.egress_service_name
     },
+    {
+      name  = "egress.serviceAccountName"
+      type  = "string"
+      value = var.egress_service_account_name != null ? var.egress_service_account_name : "${local.prefix}${var.name}-service-account"
+    },
   ]
 
   values = [

--- a/modules/sm-istio-egress/variables.tf
+++ b/modules/sm-istio-egress/variables.tf
@@ -289,3 +289,9 @@ variable "egress_create_service_account" {
   default     = true
   nullable    = false
 }
+
+variable "egress_service_account_name" {
+  type        = string
+  default     = null
+  description = "Optional override for the egress ServiceAccount name. If null or empty, defaults to '<egress.name>-service-account'."
+}

--- a/modules/sm-istio-ingress/README.md
+++ b/modules/sm-istio-ingress/README.md
@@ -183,7 +183,7 @@ For all the configuration parameters details refer to the section below
 ### Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0.0, <4.0.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.59.0, < 3.0.0 |
@@ -193,13 +193,13 @@ For all the configuration parameters details refer to the section below
 ### Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_ingress_namespace"></a> [ingress\_namespace](#module\_ingress\_namespace) | terraform-ibm-modules/namespace/ibm | v2.0.1 |
 
 ### Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [helm_release.istio_ingress](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_annotations.istio_namespace_annotations](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/annotations) | resource |
 | [kubernetes_labels.istio_namespace_labels](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/labels) | resource |
@@ -212,7 +212,7 @@ For all the configuration parameters details refer to the section below
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_add_istio_labels_annotations_to_existing_namespace"></a> [add\_istio\_labels\_annotations\_to\_existing\_namespace](#input\_add\_istio\_labels\_annotations\_to\_existing\_namespace) | Flag to add istio labels and annotations like the discovery ones or the value of var.ingress\_discovery\_custom\_configuration to an existing namespace. Default to false. If var.create\_namespace is true this flag is ignored. | `bool` | `false` | no |
 | <a name="input_cluster_config_endpoint_type"></a> [cluster\_config\_endpoint\_type](#input\_cluster\_config\_endpoint\_type) | Specify which type of endpoint to use for for cluster config access: 'default', 'private', 'vpe', 'link'. 'default' value will use the default endpoint of the cluster. | `string` | `"default"` | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Id of the target IBM Cloud OpenShift Cluster | `string` | n/a | yes |
@@ -243,6 +243,7 @@ For all the configuration parameters details refer to the section below
 | <a name="input_ingress_replicas"></a> [ingress\_replicas](#input\_ingress\_replicas) | Istio ingress deployment replicaset configuration. If the var.ingress\_autoscale\_configuration.enabled is true this value is ignored. Default to 3. | `number` | `3` | no |
 | <a name="input_ingress_resources_configuration"></a> [ingress\_resources\_configuration](#input\_ingress\_resources\_configuration) | Istio ingress resources deployment configuration. Default configuration is null and leverages on Istio default setting. | <pre>object(<br/>    {<br/>      limits : optional(object(<br/>        {<br/>          cpu : optional(string, null),<br/>          memory : optional(string, null)<br/>      }), null),<br/>      requests : optional(object(<br/>        {<br/>          cpu : optional(string, null)<br/>          memory : optional(string, null)<br/>      }), null)<br/>    }<br/>  )</pre> | `null` | no |
 | <a name="input_ingress_selectors"></a> [ingress\_selectors](#input\_ingress\_selectors) | Istio ingress selectors to route inbound ingress traffic to the expected istio gateway and to the expected workload. Default to "app": "istio-ingress" "istio": "istio-ingress". Null not allowed | `map(string)` | <pre>{<br/>  "app": "istio-ingress",<br/>  "istio": "istio-ingress"<br/>}</pre> | no |
+| <a name="input_ingress_service_account_name"></a> [ingress\_service\_account\_name](#input\_ingress\_service\_account\_name) | Optional override for the ingress ServiceAccount name. If null or empty, defaults to '<ingress.name>-service-account'. | `string` | `null` | no |
 | <a name="input_ingress_service_name"></a> [ingress\_service\_name](#input\_ingress\_service\_name) | Optional override for the ingress Service name. If null or empty, the value of var.name is used as default. | `string` | `null` | no |
 | <a name="input_ingress_service_type"></a> [ingress\_service\_type](#input\_ingress\_service\_type) | Istio ingress type for the service (svc) resource definition: possible values are LoadBalancer and ClusterIP.  Default to LoadBalancer | `string` | `"LoadBalancer"` | no |
 | <a name="input_ingress_termination_grace_period"></a> [ingress\_termination\_grace\_period](#input\_ingress\_termination\_grace\_period) | Number of seconds for the Istio ingress deployment for the grace period before terminating the pods and dropping the connections. Default to null to leverage on Istio default. | `number` | `null` | no |
@@ -259,7 +260,7 @@ For all the configuration parameters details refer to the section below
 ### Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_ingress_loadbalancer_hostname"></a> [ingress\_loadbalancer\_hostname](#output\_ingress\_loadbalancer\_hostname) | Load balancer hostname(s). For ALB: returns map with single hostname. For NLB: returns map of service name to hostname per zone. For other types: returns empty map. |
 | <a name="output_ingress_loadbalancer_ips"></a> [ingress\_loadbalancer\_ips](#output\_ingress\_loadbalancer\_ips) | Load balancer IP addresses. For NLB: returns map of service name to IP. For other types: returns map with indexed keys (ip-0, ip-1, etc). Returns empty map for ALB. |
 | <a name="output_istio_ingress_metadata"></a> [istio\_ingress\_metadata](#output\_istio\_ingress\_metadata) | Istio ingress helm release metadata |

--- a/modules/sm-istio-ingress/README.md
+++ b/modules/sm-istio-ingress/README.md
@@ -183,7 +183,7 @@ For all the configuration parameters details refer to the section below
 ### Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0.0, <4.0.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.59.0, < 3.0.0 |
@@ -193,13 +193,13 @@ For all the configuration parameters details refer to the section below
 ### Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_ingress_namespace"></a> [ingress\_namespace](#module\_ingress\_namespace) | terraform-ibm-modules/namespace/ibm | v2.0.1 |
 
 ### Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [helm_release.istio_ingress](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_annotations.istio_namespace_annotations](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/annotations) | resource |
 | [kubernetes_labels.istio_namespace_labels](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/labels) | resource |
@@ -212,7 +212,7 @@ For all the configuration parameters details refer to the section below
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_add_istio_labels_annotations_to_existing_namespace"></a> [add\_istio\_labels\_annotations\_to\_existing\_namespace](#input\_add\_istio\_labels\_annotations\_to\_existing\_namespace) | Flag to add istio labels and annotations like the discovery ones or the value of var.ingress\_discovery\_custom\_configuration to an existing namespace. Default to false. If var.create\_namespace is true this flag is ignored. | `bool` | `false` | no |
 | <a name="input_cluster_config_endpoint_type"></a> [cluster\_config\_endpoint\_type](#input\_cluster\_config\_endpoint\_type) | Specify which type of endpoint to use for for cluster config access: 'default', 'private', 'vpe', 'link'. 'default' value will use the default endpoint of the cluster. | `string` | `"default"` | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Id of the target IBM Cloud OpenShift Cluster | `string` | n/a | yes |
@@ -260,7 +260,7 @@ For all the configuration parameters details refer to the section below
 ### Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_ingress_loadbalancer_hostname"></a> [ingress\_loadbalancer\_hostname](#output\_ingress\_loadbalancer\_hostname) | Load balancer hostname(s). For ALB: returns map with single hostname. For NLB: returns map of service name to hostname per zone. For other types: returns empty map. |
 | <a name="output_ingress_loadbalancer_ips"></a> [ingress\_loadbalancer\_ips](#output\_ingress\_loadbalancer\_ips) | Load balancer IP addresses. For NLB: returns map of service name to IP. For other types: returns map with indexed keys (ip-0, ip-1, etc). Returns empty map for ALB. |
 | <a name="output_istio_ingress_metadata"></a> [istio\_ingress\_metadata](#output\_istio\_ingress\_metadata) | Istio ingress helm release metadata |

--- a/modules/sm-istio-ingress/main.tf
+++ b/modules/sm-istio-ingress/main.tf
@@ -247,6 +247,11 @@ resource "helm_release" "istio_ingress" {
       type  = "string"
       value = var.ingress_service_name
     },
+    {
+      name  = "ingress.serviceAccountName"
+      type  = "string"
+      value = var.ingress_service_account_name != null ? var.ingress_service_account_name : "${local.prefix}${var.name}-service-account"
+    },
   ]
 
   # yamlencode(local.ingress_namespace_enrollment_labels),

--- a/modules/sm-istio-ingress/variables.tf
+++ b/modules/sm-istio-ingress/variables.tf
@@ -383,3 +383,9 @@ variable "ingress_deployment_custom_annotations" {
   nullable    = true
   description = "Map of custom annotations to add to the ingress Deployment resource"
 }
+
+variable "ingress_service_account_name" {
+  type        = string
+  default     = null
+  description = "Optional override for the ingress ServiceAccount name. If null or empty, defaults to '<ingress.name>-service-account'."
+}


### PR DESCRIPTION


### Description

Add ingress_service_account_name and egress_service_account_name variables to allow customization of ServiceAccount names.

This change is backward compatible - existing deployments will continue using the same ServiceAccount names (<prefix><name>-service-account) without any modifications required.

Changes:
- Add optional service account name variables to ingress and egress modules
- Update Helm templates to use configurable serviceAccountName field
- Terraform computes default values maintaining existing naming pattern
- Users can now override with custom names when needed

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Add configurable service account names for ingress and egress

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
